### PR TITLE
Make auth cookie safe

### DIFF
--- a/src/client/app/apollo-client.ts
+++ b/src/client/app/apollo-client.ts
@@ -9,21 +9,15 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-export const context = (req: Request) => {
-  return {
-    headers: {
-      authorization: `Bearer ${req.cookies['jwt']}`,
-    },
-  };
-};
-
 export const typedQuery = async <Q extends ValueTypes['Query']>(
   query: Q,
   req: Request,
 ) => {
   const { data } = await client.query({
     query: gql(Zeus.query(query)),
-    context: context(req),
+    context: {
+      headers: { Cookie: req.headers.cookie },
+    },
   });
 
   const typedData = data as MapType<Query, Q>;

--- a/src/server/app/auth/cognito/cognito-oauth.controller.ts
+++ b/src/server/app/auth/cognito/cognito-oauth.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { SESSION_COOKIE_KEY } from 'src/server/config/constants';
 import { JwtAuthService } from '../jwt/jwt-auth.service';
 import { CognitoOauthGuard } from './cognito-oauth.guard';
 
@@ -17,7 +18,10 @@ export class CognitoOauthController {
   @UseGuards(CognitoOauthGuard)
   async cognitoAuthRedirect(@Req() req: Request, @Res() res: Response) {
     const { accessToken } = this.jwtAuthService.login(req.user);
-    res.cookie('jwt', accessToken, { httpOnly: true, sameSite: 'strict' });
+    res.cookie(SESSION_COOKIE_KEY, accessToken, {
+      httpOnly: true,
+      sameSite: 'strict',
+    });
     return res.redirect('/profile');
   }
 }

--- a/src/server/app/auth/cognito/cognito-oauth.controller.ts
+++ b/src/server/app/auth/cognito/cognito-oauth.controller.ts
@@ -17,7 +17,7 @@ export class CognitoOauthController {
   @UseGuards(CognitoOauthGuard)
   async cognitoAuthRedirect(@Req() req: Request, @Res() res: Response) {
     const { accessToken } = this.jwtAuthService.login(req.user);
-    res.cookie('jwt', accessToken);
+    res.cookie('jwt', accessToken, { httpOnly: true, sameSite: 'strict' });
     return res.redirect('/profile');
   }
 }

--- a/src/server/app/auth/google/google-oauth.controller.ts
+++ b/src/server/app/auth/google/google-oauth.controller.ts
@@ -2,6 +2,7 @@ import { Controller, Get, Req, Res, UseGuards } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { GoogleOauthGuard } from './google-oauth.guard';
 import { JwtAuthService } from '../jwt/jwt-auth.service';
+import { SESSION_COOKIE_KEY } from 'src/server/config/constants';
 
 @Controller('auth/google')
 export class GoogleOauthController {
@@ -17,7 +18,7 @@ export class GoogleOauthController {
   @UseGuards(GoogleOauthGuard)
   async googleAuthRedirect(@Req() req: Request, @Res() res: Response) {
     const { accessToken } = this.jwtAuthService.login(req.user);
-    res.cookie('jwt', accessToken, {
+    res.cookie(SESSION_COOKIE_KEY, accessToken, {
       httpOnly: true,
       sameSite: 'strict',
     });

--- a/src/server/app/auth/google/google-oauth.controller.ts
+++ b/src/server/app/auth/google/google-oauth.controller.ts
@@ -17,7 +17,10 @@ export class GoogleOauthController {
   @UseGuards(GoogleOauthGuard)
   async googleAuthRedirect(@Req() req: Request, @Res() res: Response) {
     const { accessToken } = this.jwtAuthService.login(req.user);
-    res.cookie('jwt', accessToken);
+    res.cookie('jwt', accessToken, {
+      httpOnly: true,
+      sameSite: 'strict',
+    });
     return res.redirect('/profile');
   }
 }

--- a/src/server/app/auth/jwt/jwt-auth.strategy.ts
+++ b/src/server/app/auth/jwt/jwt-auth.strategy.ts
@@ -1,4 +1,4 @@
-import { ExtractJwt, Strategy } from 'passport-jwt';
+import { Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -10,10 +10,11 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy) {
   constructor(configService: ConfigService) {
     const extractJwtFromCookie = (req) => {
       let token = null;
+
       if (req && req.cookies) {
         token = req.cookies['jwt'];
       }
-      return token || ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+      return token;
     };
 
     super({

--- a/src/server/app/auth/jwt/jwt-auth.strategy.ts
+++ b/src/server/app/auth/jwt/jwt-auth.strategy.ts
@@ -2,6 +2,7 @@ import { Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { SESSION_COOKIE_KEY } from 'src/server/config/constants';
 
 export type JwtPayload = { sub: number; username: string };
 
@@ -12,7 +13,7 @@ export class JwtAuthStrategy extends PassportStrategy(Strategy) {
       let token = null;
 
       if (req && req.cookies) {
-        token = req.cookies['jwt'];
+        token = req.cookies[SESSION_COOKIE_KEY];
       }
       return token;
     };

--- a/src/server/config/constants.ts
+++ b/src/server/config/constants.ts
@@ -1,0 +1,1 @@
+export const SESSION_COOKIE_KEY = 'session';

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -3,6 +3,8 @@ import { Test } from '@nestjs/testing';
 import { AppModule } from 'src/server/app/app.module';
 import { INestApplication } from '@nestjs/common';
 import { getConnection } from 'typeorm';
+import * as cookieParser from 'cookie-parser';
+
 import { usersFactory, ordersFactory, thingsFactory } from 'test/factories';
 import { UsersService } from 'src/server/app/users/users.service';
 import { User } from 'src/server/app/users/user.entity';
@@ -25,6 +27,7 @@ describe('Application', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
     await app.init();
 
     usersService = app.get(UsersService);

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -2,6 +2,7 @@ import * as request from 'supertest';
 
 import { JwtAuthService } from 'src/server/app/auth/jwt/jwt-auth.service';
 import { User } from 'src/server/app/users/user.entity';
+import { SESSION_COOKIE_KEY } from 'src/server/config/constants';
 
 export const login = (
   agent: request.Test,
@@ -9,5 +10,5 @@ export const login = (
   authService: JwtAuthService,
 ) => {
   const jwtToken = authService.login(user).accessToken;
-  return agent.set('Authorization', `Bearer ${jwtToken}`);
+  return agent.set('Cookie', [`${SESSION_COOKIE_KEY}=${jwtToken}`]);
 };


### PR DESCRIPTION
Resolves https://github.com/thisismydesign/nestjs-starter/issues/21

Sets `HttpOnly` and `SameSite` attributes on auth cookie. Resolves cookie forwarding to GraphQL.
