### PR TITLE
Checking for and extracting JWT from Auth as Bearer Token

### DIFF
--- a/src/server/app/auth/jwt/jwt-auth.strategy.ts
+++ b/src/server/app/auth/jwt/jwt-auth.strategy.ts
@@ -1,26 +1,28 @@
-import { Strategy } from 'passport-jwt';
+import { Strategy, ExtractJwt } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SESSION_COOKIE_KEY } from 'src/server/config/constants';
 
 export type JwtPayload = { sub: number; username: string };
-
 @Injectable()
 export class JwtAuthStrategy extends PassportStrategy(Strategy) {
   constructor(configService: ConfigService) {
-    const extractJwtFromCookie = (req) => {
+    const extractJwtFromRequest = (req) => {
       let token = null;
 
-      if (req && req.cookies) {
+      if (ExtractJwt.fromAuthHeaderAsBearerToken()(req)) {
+        token = ExtractJwt.fromAuthHeaderAsBearerToken()(req);
+      } else if (req && req.cookies && req.cookies[SESSION_COOKIE_KEY]) {
         token = req.cookies[SESSION_COOKIE_KEY];
       }
       return token;
     };
 
     super({
-      jwtFromRequest: extractJwtFromCookie,
+      jwtFromRequest: extractJwtFromRequest,
       ignoreExpiration: false,
+
       secretOrKey: configService.get<string>('JWT_SECRET'),
     });
   }


### PR DESCRIPTION
Extending JWT extraction. Utilizing `passport-jwt.ExtractJwt` to get the JWT from the `Authorization` header as `Bearer` token and extract from the session cookie. Also renaming the function to reflect the more general nature. 

Fixes #52 