### PR TITLE
Add @babel/runtime to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.16",
+    "@babel/runtime": "^7.18.9",
     "@nestjs/common": "^7.5.1",
     "@nestjs/config": "^0.6.3",
     "@nestjs/core": "^7.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,6 +448,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.12.13", "@babel/template@^7.3.3":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.13.tgz#530265be8a2589dbb37523844c5bcb55947fb327"


### PR DESCRIPTION
Got the following error when starting the server:

```
/app/node_modules/next/dist/next-server/lib/side-effect.js
Module not found: Can't resolve '/app/node_modules/next/node_modules/@babel/runtime/helpers/assertThisInitialized' in '/app/node_modules/next/dist/next-server/lib'
```

Although it did not break the start, it resulted in 500 for Next.js pages masked by https://github.com/vercel/next.js/issues/4660.

Solved as described in https://bobbyhadz.com/blog/react-module-not-found-cant-resolve-babel-runtime and https://stackoverflow.com/questions/57737270/how-to-fix-module-not-found-cant-resolve-babel-runtime-helpers-objectwitho