### PR TITLE
Cache docker layers in CI instead of pushing the whole image to the registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
     permissions:
       contents: read
       packages: write
-    # outputs:
-    #   docker-tag: ${{ steps.meta.outputs.tags }}
+    outputs:
+      docker-tag: ${{ steps.meta.outputs.tags }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         # push: true
-        load: true
+        # load: true
         file: Dockerfile.prod
         tags: ${{ needs.build-docker-image.outputs.docker-tag }}
         cache-from: type=gha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-docker-image]
-    # env:
+    env:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
       DUMMY_MOUNT: .:/dummy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   node_version: "14.x"
-  REGISTRY: localhost:5000 # https://stackoverflow.com/a/57644157/2771889
+  REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Build image
         id: docker_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
           images: local/${{ github.repository }}
 
       - name: Build image
-        id: docker_build
         uses: docker/build-push-action@v3
         with:
           file: Dockerfile.prod
@@ -66,7 +65,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build image
-      id: docker_build
       uses: docker/build-push-action@v3
       with:
         load: true
@@ -98,7 +96,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build image
-      id: docker_build
       uses: docker/build-push-action@v3
       with:
         load: true
@@ -130,7 +127,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build image
-      id: docker_build
       uses: docker/build-push-action@v3
       with:
         load: true
@@ -163,7 +159,6 @@ jobs:
       uses: docker/setup-buildx-action@v2
 
     - name: Build image
-      id: docker_build
       uses: docker/build-push-action@v3
       with:
         load: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,6 @@ jobs:
     - name: Pull images
       run: docker-compose pull
 
-    - name: Show images
-      run: docker image ls -a
-
     - name: Run lint
       run: docker-compose run web yarn lint
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,44 +40,35 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      docker-tag: ${{ steps.meta.outputs.tags }}
+    # outputs:
+    #   docker-tag: ${{ steps.meta.outputs.tags }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx to be able to use caching
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@v1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Log in to the Container registry
+      #   uses: docker/login-action@v1
+      #   with:
+      #     registry: ${{ env.REGISTRY }}
+      #     username: ${{ github.actor }}
+      #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v3
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@v3
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v3
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
-      - name: Build and push
+      - name: Build image
         id: docker_build
         uses: docker/build-push-action@v3
         with:
           # push: true
           file: Dockerfile.prod
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: nestjs-starter:local
           cache-from: type=gha
           cache-to: type=gha
 
@@ -89,14 +80,27 @@ jobs:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
+    - name: Set up Docker Buildx to be able to use caching
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      id: docker_build
+      uses: docker/build-push-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        # push: true
+        file: Dockerfile.prod
+        tags: nestjs-starter:local
+        cache-from: type=gha
+        cache-to: type=gha
+
+    # - name: Log in to the Container registry
+    #   uses: docker/login-action@v1
+    #   with:
+    #     registry: ${{ env.REGISTRY }}
+    #     username: ${{ github.actor }}
+    #     password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Init
       run: ./scripts/docker_setup_init.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Docker init
         run: docker-compose run --rm web sh -c 'exit 0'
 
-  build-and-upload-docker-image:
+  build-docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -62,11 +62,19 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
+      - name: Cache Docker layers
+        uses: actions/cache@v3
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
-          push: true
+          # push: true
           file: Dockerfile.prod
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -77,8 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-and-upload-docker-image]
-    env:
-      NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    # env:
+    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
     steps:
     - uses: actions/checkout@v2
@@ -103,8 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-and-upload-docker-image]
-    env:
-      NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    # env:
+    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
     steps:
     - uses: actions/checkout@v2
@@ -129,8 +137,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-and-upload-docker-image]
-    env:
-      NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    # env:
+    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
     steps:
     - uses: actions/checkout@v2
@@ -155,8 +163,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-and-upload-docker-image]
-    env:
-      NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    # env:
+    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
       DUMMY_MOUNT: .:/dummy
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up Docker Buildx to be able to use caching
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v2
 
       # - name: Log in to the Container registry
       #   uses: docker/login-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-upload-docker-image]
+    needs: [build-docker-image]
     # env:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
@@ -110,7 +110,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-upload-docker-image]
+    needs: [build-docker-image]
     # env:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
@@ -136,7 +136,7 @@ jobs:
   test-request:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-upload-docker-image]
+    needs: [build-docker-image]
     # env:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
 
@@ -162,7 +162,7 @@ jobs:
   test-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-and-upload-docker-image]
+    needs: [build-docker-image]
     # env:
     #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
       DUMMY_MOUNT: .:/dummy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,13 @@ on:
   pull_request:
     types: [opened, reopened]
 
-env:
-  node_version: "14.x"
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   verify-docker-setup:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Init
         run: ./scripts/docker_setup_init.sh
@@ -33,9 +28,6 @@ jobs:
   build-docker-image:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      packages: write
     outputs:
       docker-tag: ${{ steps.meta.outputs.tags }}
 
@@ -45,27 +37,18 @@ jobs:
       - name: Set up Docker Buildx to be able to use caching
         uses: docker/setup-buildx-action@v2
 
-      # - name: Log in to the Container registry
-      #   uses: docker/login-action@v1
-      #   with:
-      #     registry: ${{ env.REGISTRY }}
-      #     username: ${{ github.actor }}
-      #     password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: local/${{ github.repository }}
 
       - name: Build image
         id: docker_build
         uses: docker/build-push-action@v3
         with:
-          # push: true
           file: Dockerfile.prod
           tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha
 
@@ -86,19 +69,11 @@ jobs:
       id: docker_build
       uses: docker/build-push-action@v3
       with:
-        # push: true
-        # load: true
+        load: true
         file: Dockerfile.prod
         tags: ${{ needs.build-docker-image.outputs.docker-tag }}
         cache-from: type=gha
         cache-to: type=gha
-
-    # - name: Log in to the Container registry
-    #   uses: docker/login-action@v1
-    #   with:
-    #     registry: ${{ env.REGISTRY }}
-    #     username: ${{ github.actor }}
-    #     password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Init
       run: ./scripts/docker_setup_init.sh
@@ -116,18 +91,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-docker-image]
-    # env:
-    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    env:
+      NESTJS_STARTER_IMAGE: ${{ needs.build-docker-image.outputs.docker-tag }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
+    - name: Set up Docker Buildx to be able to use caching
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      id: docker_build
+      uses: docker/build-push-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        load: true
+        file: Dockerfile.prod
+        tags: ${{ needs.build-docker-image.outputs.docker-tag }}
+        cache-from: type=gha
+        cache-to: type=gha
 
     - name: Init
       run: ./scripts/docker_setup_init.sh
@@ -142,18 +123,24 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-docker-image]
-    # env:
-    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    env:
+      NESTJS_STARTER_IMAGE: ${{ needs.build-docker-image.outputs.docker-tag }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
+    - name: Set up Docker Buildx to be able to use caching
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      id: docker_build
+      uses: docker/build-push-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        load: true
+        file: Dockerfile.prod
+        tags: ${{ needs.build-docker-image.outputs.docker-tag }}
+        cache-from: type=gha
+        cache-to: type=gha
 
     - name: Init
       run: ./scripts/docker_setup_init.sh
@@ -169,18 +156,24 @@ jobs:
     timeout-minutes: 10
     needs: [build-docker-image]
     env:
-    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+      NESTJS_STARTER_IMAGE: ${{ needs.build-docker-image.outputs.docker-tag }}
       DUMMY_MOUNT: .:/dummy
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Log in to the Container registry
-      uses: docker/login-action@v1
+    - name: Set up Docker Buildx to be able to use caching
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build image
+      id: docker_build
+      uses: docker/build-push-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        load: true
+        file: Dockerfile.prod
+        tags: ${{ needs.build-docker-image.outputs.docker-tag }}
+        cache-from: type=gha
+        cache-to: type=gha
 
     - name: Init
       run: ./scripts/docker_setup_init.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,11 +56,11 @@ jobs:
       #     username: ${{ github.actor }}
       #     password: ${{ secrets.GITHUB_TOKEN }}
 
-      # - name: Extract metadata (tags, labels) for Docker
-      #   id: meta
-      #   uses: docker/metadata-action@v3
-      #   with:
-      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.IMAGE_NAME }}
 
       - name: Build image
         id: docker_build
@@ -68,7 +68,8 @@ jobs:
         with:
           # push: true
           file: Dockerfile.prod
-          tags: nestjs-starter:local
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha
 
@@ -76,8 +77,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [build-docker-image]
-    # env:
-    #   NESTJS_STARTER_IMAGE: ${{ needs.build-and-upload-docker-image.outputs.docker-tag }}
+    env:
+      NESTJS_STARTER_IMAGE: ${{ needs.build-docker-image.outputs.docker-tag }}
 
     steps:
     - uses: actions/checkout@v3
@@ -92,7 +93,7 @@ jobs:
         # push: true
         load: true
         file: Dockerfile.prod
-        tags: nestjs-starter:local
+        tags: ${{ needs.build-docker-image.outputs.docker-tag }}
         cache-from: type=gha
         cache-to: type=gha
 
@@ -108,6 +109,9 @@ jobs:
 
     - name: Pull images
       run: docker-compose pull
+
+    - name: Show images
+      run: docker image ls -a
 
     - name: Run lint
       run: docker-compose run web yarn lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
-concurrency:
-  group: ${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
-
 jobs:
   verify-docker-setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   node_version: "14.x"
-  REGISTRY: ghcr.io
+  REGISTRY: localhost:5000 # https://stackoverflow.com/a/57644157/2771889
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build image
         id: docker_build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
       uses: docker/build-push-action@v3
       with:
         # push: true
+        load: true
         file: Dockerfile.prod
         tags: nestjs-starter:local
         cache-from: type=gha


### PR DESCRIPTION
https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md#github-cache
https://github.com/docker/build-push-action/blob/master/docs/advanced/export-docker.md

https://stackoverflow.com/a/57644157/2771889
https://stackoverflow.com/a/47878334/2771889
