### PR TITLE
Fix Cypress docker on linux can't resolve host.docker.internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ docker-compose exec web yarn lint
 docker-compose exec web yarn test
 docker-compose exec web yarn test:request
 docker-compose exec web yarn build
-docker run -it -v $PWD:/e2e -w /e2e --entrypoint=cypress cypress/included:10.0.3 run --config-file cypress.docker.config.ts
+docker run -it -v $PWD:/e2e -w /e2e --net=host --entrypoint=cypress cypress/included:10.0.3 run --config-file cypress.docker.config.ts
 ```
 
 ## Functionality

--- a/cypress.docker.config.ts
+++ b/cypress.docker.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'cypress';
 
 export default defineConfig({
   e2e: {
-    baseUrl: 'http://host.docker.internal:3000/',
+    baseUrl: 'http://localhost:3000/',
     videoUploadOnPasses: false,
   },
 });


### PR DESCRIPTION
The Cypress docker command in README fails for linux users since Docker on linux doesn't auto-resolve host.docker.internal