### PR TITLE
fix: exclude .js files from ts-jest (resolves #468 )

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,9 +5,9 @@ const config: Config.InitialOptions = {
   modulePaths: ['.'],
   testRegex: '.*\\.spec\\.ts$',
   transform: {
-    '^.+\\.(t|j)s$': 'ts-jest',
+    '^.+\\.ts$': 'ts-jest',
   },
-  collectCoverageFrom: ['src/server/**/*.(t|j)s'],
+  collectCoverageFrom: ['src/server/**/*.ts'],
   coveragePathIgnorePatterns: ['src/server/console', 'src/server/migration'],
   coverageDirectory: 'coverage',
   testEnvironment: 'node',


### PR DESCRIPTION
ts-jest should not process javascript files, as it can lead to significant performance drop.

Check issue https://github.com/thisismydesign/nestjs-starter/issues/468

and also issue https://github.com/kulshekhar/ts-jest/issues/4294


resolves #468